### PR TITLE
added ca injection for secrets and configmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The functionalities are the following:
 2. [Ability to create java keystore and truststore from the certificates](#Creating-java-keystore-and-truststore)
 3. [Ability to show info regarding the certificates](#Showing-info-on-the-certificates)
 4. [Ability to alert when a certificate is about to expire](#Alerting-when-a-certificate-is-about-to-expire)
-5. [Ability to inject ca bundles in ValidatingWebhookConfiguration, MutatingWebhookConfiguration, CustomResourceDefinition object](#CA-injection)
+5. [Ability to inject ca bundles in Secrets, ConfigMaps, ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CustomResourceDefinition objects](#CA-injection)
 
 All these feature are activated via opt-in annotations.
 

--- a/charts/cert-utils-operator/templates/role.yaml
+++ b/charts/cert-utils-operator/templates/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - events
   - secrets
+  - configmaps
   verbs:
   - "*"
 # Operator Business Logic

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - events
   - secrets
+  - configmaps
   verbs:
   - "*"
 # Operator Business Logic

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ replace (
 	k8s.io/kube-state-metrics => k8s.io/kube-state-metrics v1.6.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.12
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
+	replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ replace (
 	k8s.io/kube-state-metrics => k8s.io/kube-state-metrics v1.6.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.12
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
-	replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -128,6 +129,7 @@ github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
+github.com/gobuffalo/envy v1.6.15 h1:OsV5vOpHYUpP7ZLS6sem1y40/lNX1BZj+ynMiRi21lQ=
 github.com/gobuffalo/envy v1.6.15/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v0.0.0-20170330071051-c0656edd0d9e/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -205,6 +207,7 @@ github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -229,6 +232,7 @@ github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983 h1:wL11wNW7dhKIcRCHSm4sHKPWz0tt4mwBsVodG7+Xyqg=
 github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
@@ -313,6 +317,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v0.0.0-20151117072312-300106c228d5/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
@@ -323,6 +328,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -446,6 +452,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190213015956-f7e1b50d2251/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350 h1:0USRhKWpISljvJE8egltEaoJb+VD0IUA4eOH6W1yss8=
 golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -457,6 +464,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -510,6 +518,7 @@ k8s.io/code-generator v0.0.0-20181203235156-f8cba74510f3/go.mod h1:MYiN+ZJZ9HkET
 k8s.io/gengo v0.0.0-20181106084056-51747d6e00da/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a h1:QoHVuRquf80YZ+/bovwxoMO3Q/A3nt3yTgS0/0nejuk=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/helm v2.13.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -530,6 +539,7 @@ k8s.io/kubernetes v1.11.8-beta.0.0.20190124204751-3a10094374f2/go.mod h1:ocZa8+6
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 sigs.k8s.io/controller-runtime v0.1.12 h1:ovDq28E64PeY1yR+6H7DthakIC09soiDCrKvfP2tPYo=
 sigs.k8s.io/controller-runtime v0.1.12/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
+sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde h1:ZkaHf5rNYzIB6CB82keKMQNv7xxkqT0ylOBdfJPfi+k=
 sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde/go.mod h1:ATWLRP3WGxuAN9HcT2LaKHReXIH+EZGzRuMHuxjXfhQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=

--- a/pkg/controller/cainjection/configmap_controller.go
+++ b/pkg/controller/cainjection/configmap_controller.go
@@ -1,0 +1,242 @@
+package cainjection
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"time"
+
+	"github.com/redhat-cop/cert-utils-operator/pkg/controller/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+// newReconciler returns a new reconcile.Reconciler
+func newConfigmapReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileConfigmap{client: mgr.GetClient(), scheme: mgr.GetScheme(), recorder: mgr.GetRecorder("configmap-ca-injection-controller")}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func addConfigmapReconciler(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("configmap-ca-injection-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	isAnnotatedSecret := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSecret, _ := e.MetaOld.GetAnnotations()[certAnnotationSecret]
+			newSecret, _ := e.MetaNew.GetAnnotations()[certAnnotationSecret]
+			return oldSecret != newSecret
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			_, ok1 := e.Meta.GetAnnotations()[certAnnotationSecret]
+			return ok1
+		},
+	}
+
+	// Watch for changes to primary resource CRD
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{}, isAnnotatedSecret)
+	if err != nil {
+		return err
+	}
+
+	isContentChanged := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			_, ok := e.ObjectNew.(*corev1.ConfigMap)
+			if !ok {
+				return false
+			}
+			return true
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			_, ok := e.Object.(*corev1.ConfigMap)
+			if !ok {
+				return false
+			}
+			_, ok1 := e.Meta.GetAnnotations()[certAnnotationSecret]
+			return ok1
+		},
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner ValidatingWebhookConfiguration
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &enqueueRequestForReferecingConfigmaps{
+		Client: mgr.GetClient(),
+	}, isContentChanged)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileSecret{}
+
+// ReconcileCRD reconciles a mutatingWebhookConfiguration object
+type ReconcileConfigmap struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
+}
+
+// Reconcile reads that state of the cluster for a mutatingWebhookConfiguration object and makes changes based on the state read
+// and what is in the mutatingWebhookConfiguration.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileConfigmap) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling configmap")
+
+	// Fetch the mutatingWebhookConfiguration instance
+	instance := &corev1.ConfigMap{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	caBundle := []byte{}
+
+	if secretNamespacedName, ok := instance.GetAnnotations()[certAnnotationSecret]; ok {
+		//we need to inject the secret ca
+		caBundle, err = r.getSecretCA(secretNamespacedName[strings.Index(secretNamespacedName, "/")+1:], secretNamespacedName[:strings.Index(secretNamespacedName, "/")])
+		if err != nil {
+			log.Error(err, "unable to retrive ca from secret", "secret", secretNamespacedName)
+			return r.manageError(err, instance)
+		}
+	}
+	if len(caBundle) == 0 {
+		delete(instance.Data, util.CA)
+	} else {
+		if instance.Data == nil {
+			instance.Data = map[string]string{}
+		}
+		buffer := bytes.NewBuffer(caBundle)
+		instance.Data[util.CA] = buffer.String()
+	}
+	err = r.client.Update(context.TODO(), instance)
+
+	if err != nil {
+		return r.manageError(err, instance)
+	}
+
+	return reconcile.Result{}, err
+}
+
+func matchSecretWithConfigmaps(c client.Client, secret types.NamespacedName) ([]corev1.ConfigMap, error) {
+	configmapList := &corev1.ConfigMapList{}
+	err := c.List(context.TODO(), &client.ListOptions{}, configmapList)
+	if err != nil {
+		log.Error(err, "unable to list secret for this namespace: ", "namespace", secret.Namespace)
+		return []corev1.ConfigMap{}, err
+	}
+	result := []corev1.ConfigMap{}
+	for _, configmap := range configmapList.Items {
+		if secretNamespacedName := configmap.GetAnnotations()[certAnnotationSecret]; secretNamespacedName[strings.Index(secretNamespacedName, "/")+1:] == secret.Name && secretNamespacedName[:strings.Index(secretNamespacedName, "/")] == secret.Namespace {
+			result = append(result, configmap)
+		}
+	}
+	return result, nil
+}
+
+type enqueueRequestForReferecingConfigmaps struct {
+	client.Client
+}
+
+// trigger a router reconcile event for those routes that reference this secret
+func (e *enqueueRequestForReferecingConfigmaps) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	configmaps, _ := matchSecretWithConfigmaps(e.Client, types.NamespacedName{
+		Name:      evt.Meta.GetName(),
+		Namespace: evt.Meta.GetNamespace(),
+	})
+	for _, configmap := range configmaps {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      configmap.GetName(),
+			Namespace: configmap.GetNamespace(),
+		}})
+	}
+}
+
+// Update implements EventHandler
+// trigger a router reconcile event for those routes that reference this secret
+func (e *enqueueRequestForReferecingConfigmaps) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	configmaps, _ := matchSecretWithConfigmaps(e.Client, types.NamespacedName{
+		Name:      evt.MetaNew.GetName(),
+		Namespace: evt.MetaNew.GetNamespace(),
+	})
+	for _, configmap := range configmaps {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      configmap.GetName(),
+			Namespace: configmap.GetNamespace(),
+		}})
+	}
+}
+
+// Delete implements EventHandler
+func (e *enqueueRequestForReferecingConfigmaps) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	return
+}
+
+// Generic implements EventHandler
+func (e *enqueueRequestForReferecingConfigmaps) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	configmaps, _ := matchSecretWithConfigmaps(e.Client, types.NamespacedName{
+		Name:      evt.Meta.GetName(),
+		Namespace: evt.Meta.GetNamespace(),
+	})
+	for _, configmap := range configmaps {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      configmap.GetName(),
+			Namespace: configmap.GetNamespace(),
+		}})
+	}
+}
+
+func (r *ReconcileConfigmap) getSecretCA(secretName string, secretNamespace string) ([]byte, error) {
+	secret := &corev1.Secret{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{
+		Namespace: secretNamespace,
+		Name:      secretName,
+	}, secret)
+	if err != nil {
+		log.Error(err, "unable to find referenced secret", "secret", secretName)
+		return []byte{}, err
+	}
+	return secret.Data[util.CA], nil
+}
+
+func (r *ReconcileConfigmap) manageError(issue error, instance runtime.Object) (reconcile.Result, error) {
+	r.recorder.Event(instance, "Warning", "ProcessingError", issue.Error())
+	return reconcile.Result{
+		RequeueAfter: time.Minute * 2,
+		Requeue:      true,
+	}, nil
+}

--- a/pkg/controller/cainjection/secret_controller.go
+++ b/pkg/controller/cainjection/secret_controller.go
@@ -1,0 +1,260 @@
+package cainjection
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/redhat-cop/cert-utils-operator/pkg/controller/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+// newReconciler returns a new reconcile.Reconciler
+func newSecretReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileSecret{client: mgr.GetClient(), scheme: mgr.GetScheme(), recorder: mgr.GetRecorder("secret-ca-injection-controller")}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func addSecretReconciler(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("secret-ca-injection-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	isAnnotatedSecret := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newSecret, ok := e.ObjectNew.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			if newSecret.Type != util.TLSSecret {
+				return false
+			}
+			return true
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			secret, ok := e.Object.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			if secret.Type != util.TLSSecret {
+				return false
+			}
+			_, ok1 := e.Meta.GetAnnotations()[certAnnotationSecret]
+			return ok1
+		},
+	}
+
+	// Watch for changes to primary resource CRD
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, isAnnotatedSecret)
+	if err != nil {
+		return err
+	}
+
+	isContentChanged := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSecret, ok := e.ObjectOld.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			newSecret, ok := e.ObjectNew.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			if newSecret.Type != util.TLSSecret {
+				return false
+			}
+			return !reflect.DeepEqual(newSecret.Data[util.CA], oldSecret.Data[util.CA])
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			secret, ok := e.Object.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			if secret.Type != util.TLSSecret {
+				return false
+			}
+			return true
+		},
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner ValidatingWebhookConfiguration
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &enqueueRequestForReferecingSecrets{
+		Client: mgr.GetClient(),
+	}, isContentChanged)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileSecret{}
+
+// ReconcileCRD reconciles a mutatingWebhookConfiguration object
+type ReconcileSecret struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
+}
+
+// Reconcile reads that state of the cluster for a mutatingWebhookConfiguration object and makes changes based on the state read
+// and what is in the mutatingWebhookConfiguration.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling secret")
+
+	// Fetch the mutatingWebhookConfiguration instance
+	instance := &corev1.Secret{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	caBundle := []byte{}
+
+	if secretNamespacedName, ok := instance.GetAnnotations()[certAnnotationSecret]; ok {
+		//we need to inject the secret ca
+		caBundle, err = r.getSecretCA(secretNamespacedName[strings.Index(secretNamespacedName, "/")+1:], secretNamespacedName[:strings.Index(secretNamespacedName, "/")])
+		if err != nil {
+			log.Error(err, "unable to retrive ca from secret", "secret", secretNamespacedName)
+			return r.manageError(err, instance)
+		}
+	}
+	if len(caBundle) == 0 {
+		delete(instance.Data, util.CA)
+	} else {
+		instance.Data[util.CA] = caBundle
+	}
+
+	err = r.client.Update(context.TODO(), instance)
+
+	if err != nil {
+		return r.manageError(err, instance)
+	}
+
+	return reconcile.Result{}, err
+}
+
+func matchSecretWithSecret(c client.Client, secret types.NamespacedName) ([]corev1.Secret, error) {
+	secretList := &corev1.SecretList{}
+	err := c.List(context.TODO(), &client.ListOptions{}, secretList)
+	if err != nil {
+		log.Error(err, "unable to list secret for this namespace: ", "namespace", secret.Namespace)
+		return []corev1.Secret{}, err
+	}
+	result := []corev1.Secret{}
+	for _, tsecret := range secretList.Items {
+		if secretNamespacedName := tsecret.GetAnnotations()[certAnnotationSecret]; secretNamespacedName[strings.Index(secretNamespacedName, "/")+1:] == secret.Name && secretNamespacedName[:strings.Index(secretNamespacedName, "/")] == secret.Namespace {
+			result = append(result, tsecret)
+		}
+	}
+	return result, nil
+}
+
+type enqueueRequestForReferecingSecrets struct {
+	client.Client
+}
+
+// trigger a router reconcile event for those routes that reference this secret
+func (e *enqueueRequestForReferecingSecrets) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	secrets, _ := matchSecretWithSecret(e.Client, types.NamespacedName{
+		Name:      evt.Meta.GetName(),
+		Namespace: evt.Meta.GetNamespace(),
+	})
+	for _, secret := range secrets {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      secret.GetName(),
+			Namespace: secret.GetNamespace(),
+		}})
+	}
+}
+
+// Update implements EventHandler
+// trigger a router reconcile event for those routes that reference this secret
+func (e *enqueueRequestForReferecingSecrets) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	secrets, _ := matchSecretWithSecret(e.Client, types.NamespacedName{
+		Name:      evt.MetaNew.GetName(),
+		Namespace: evt.MetaNew.GetNamespace(),
+	})
+	for _, secret := range secrets {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      secret.GetName(),
+			Namespace: secret.GetNamespace(),
+		}})
+	}
+}
+
+// Delete implements EventHandler
+func (e *enqueueRequestForReferecingSecrets) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	return
+}
+
+// Generic implements EventHandler
+func (e *enqueueRequestForReferecingSecrets) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	secrets, _ := matchSecretWithSecret(e.Client, types.NamespacedName{
+		Name:      evt.Meta.GetName(),
+		Namespace: evt.Meta.GetNamespace(),
+	})
+	for _, secret := range secrets {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      secret.GetName(),
+			Namespace: secret.GetNamespace(),
+		}})
+	}
+}
+
+func (r *ReconcileSecret) getSecretCA(secretName string, secretNamespace string) ([]byte, error) {
+	secret := &corev1.Secret{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{
+		Namespace: secretNamespace,
+		Name:      secretName,
+	}, secret)
+	if err != nil {
+		log.Error(err, "unable to find referenced secret", "secret", secretName)
+		return []byte{}, err
+	}
+	return secret.Data[util.CA], nil
+}
+
+func (r *ReconcileSecret) manageError(issue error, instance runtime.Object) (reconcile.Result, error) {
+	r.recorder.Event(instance, "Warning", "ProcessingError", issue.Error())
+	return reconcile.Result{
+		RequeueAfter: time.Minute * 2,
+		Requeue:      true,
+	}, nil
+}

--- a/pkg/controller/cainjection/validatingwebhookconfiguration_controller.go
+++ b/pkg/controller/cainjection/validatingwebhookconfiguration_controller.go
@@ -59,6 +59,14 @@ func Add(mgr manager.Manager) error {
 	if err != nil {
 		return err
 	}
+	err = addSecretReconciler(mgr, newSecretReconciler(mgr))
+	if err != nil {
+		return err
+	}
+	err = addConfigmapReconciler(mgr, newConfigmapReconciler(mgr))
+	if err != nil {
+		return err
+	}
 	return addValidating(mgr, newValidatingReconciler(mgr))
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -26,4 +26,5 @@ Test ca-injection
 
 ```shell
 oc apply -f ./test/webhookconfiguration.yaml
+oc apply -f ./test/ca_injection_in_secret_configmap.yaml
 ```

--- a/test/ca_injection_in_secret_configmap.yaml
+++ b/test/ca_injection_in_secret_configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    cert-utils-operator.redhat-cop.io/injectca-from-secret: test-cert-utils/test1
+  name: test-inject-ca
+  namespace: test-cert-utils
+type: kubernetes.io/tls
+stringData:
+  tls.crt: ""
+  tls.key: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    cert-utils-operator.redhat-cop.io/injectca-from-secret: test-cert-utils/test1
+  name: test-inject-ca-cm
+  namespace: test-cert-utils   


### PR DESCRIPTION
this PR addresses #29 by adding the following feature:
In addition to those objects, it is also possible to inject ca bundles from secrets to secrets and configmaps:

1. `secrets`: the secret must of type: `kubernetes.io/tls`. These types of secret must contain the `tls.crt` and `tls.key` keys, but is this case those keys are going to be presumably empty. So it is recommended to create these secrets as follows:
  
  ```yaml
  apiVersion: v1
  kind: Secret
  metadata:
    annotations:
      cert-utils-operator.redhat-cop.io/injectca-from-secret: test-cert-utils/test1
    name: test-inject-ca
    namespace: test-cert-utils
  type: kubernetes.io/tls
  stringData:
    tls.crt: ""
    tls.key: ""
  ```

2. `confimaps`: the ca bundle will be injected in this key `ca.crt`, here is an example:

  ```yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    annotations:
      cert-utils-operator.redhat-cop.io/injectca-from-secret: test-cert-utils/test1
    name: test-inject-ca-cm
    namespace: test-cert-utils
  ```

[Projected volumes](https://kubernetes.io/docs/concepts/storage/volumes/#projected) can be use dto merge the caBundle with other pieces of configuration and or change the key name.