### PR TITLE
Add extra helm chart values

### DIFF
--- a/charts/cert-utils-operator/templates/operator.yaml
+++ b/charts/cert-utils-operator/templates/operator.yaml
@@ -12,6 +12,13 @@ spec:
     metadata:
       labels:
         name: cert-utils-operator
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: cert-utils-operator
       containers:
@@ -19,6 +26,9 @@ spec:
           image: quay.io/redhat-cop/cert-utils-operator:{{ .Values.image_tag }}
           command:
           - cert-utils-operator
+          {{- if .Values.args.jsonLog }}
+          - --zap-encoder json
+          {{- end }}
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -32,4 +42,4 @@ spec:
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.namespace              
+                  fieldPath: metadata.namespace

--- a/charts/cert-utils-operator/values.yaml
+++ b/charts/cert-utils-operator/values.yaml
@@ -1,1 +1,7 @@
 image_tag: 1.2.3
+
+podAnnotations: {}
+podLabels: {}
+
+args:
+  jsonLog: false


### PR DESCRIPTION
Some organizations require their pods to be annotated with specific labels which are then used by various tools (such as log parsers etc.). This PR adds `podLabels` and `podAnnotations` to the helm chart to address this.

Furthermore, this PR also makes `json` logging configurable. Whilst it is supported by the operator program via zap flags, the ability to use it is not exposed via the helm chart.