### PR TITLE
Disable devel mode when installed with helm

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -52,6 +52,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --zap-devel=false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:


### PR DESCRIPTION
Affected version: 1.3.9, 1.3.0 (not verified others)

I'm seeing about 20 lines per second with DEBUG messages like this:

```
2022-04-22T12:09:28.875Z        DEBUG   util.api        object is not ConditionsAware, not setting status
```
As Secrets and ConfigMaps don't have `.status` - this is somehow expected.

It seems some `zap-devel`mode is enabled by default. At least `/manager --help` says, that the default for `zap-devel` is `true`.

Disabling devel mode will change the log level to Info (instead of debug), encoder to json (instead of console) and will only print stacktraces on errors (instead of warnings)