### PR TITLE
[WIP] use correct Service name in ServiceMonitor kustomization

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,12 +49,12 @@ vars:
   objref:
     kind: Service
     version: v1
-    name: controller-manager-metrics-service
+    name: cert-utils-operator-controller-manager-metrics-service
 - name: METRICS_SERVICE_NAMESPACE
   objref:
     kind: Service
     version: v1
-    name: controller-manager-metrics-service
+    name: cert-utils-operator-controller-manager-metrics-service
   fieldref:
     fieldpath: metadata.namespace
 - name: ROLE_NAME

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: cert-utils-operator
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: cert-utils-operator-certs
-  name: controller-manager-metrics-service
+  name: cert-utils-operator-controller-manager-metrics-service
   namespace: system
 spec:
   ports:


### PR DESCRIPTION
The following kustomization file references a `Service` with a generic name (`controller-manager-metrics-service`).
https://github.com/redhat-cop/cert-utils-operator/blob/f471876d07cd35a27cc8e0b176c5ef5afa52727f/config/default/kustomization.yaml#L48-L59

This doesn't work because we need to use unique names for the `Service` definitions in case multiple operators are installed in the same namespace.

Because of the `Service` name mismatch, the defaults are always used which causes problems if the operator is installed to an unconventional namespace.

This PR simply corrects the service name so the correct values are used in the resulting `ServiceMonitor`