### PR TITLE
Update rules.yaml

### DIFF
--- a/config/prometheus/rules.yaml
+++ b/config/prometheus/rules.yaml
@@ -15,9 +15,9 @@ spec:
         - alert: CertificateApproachingExpiration
           annotations:
             message: >-
-              Certificate {{ $labels.namespace }}/{{ $labels.name }} is at 85% of its lifetime
+              Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} is at 85% of its lifetime
             summary: >-
-              Certificate {{ $labels.namespace }}/{{ $labels.name }} is at 85% of its lifetime
+              Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} is at 85% of its lifetime
           expr: |
             cert:time_to_expiration:sec/cert:validity_duration:sec < 0.15
           labels:
@@ -25,9 +25,9 @@ spec:
         - alert: CertificateIsAboutToExpire
           annotations:
             message: >-
-              Certificate {{ $labels.namespace }}/{{ $labels.name }} is at 95% of its lifetime
+              Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} is at 95% of its lifetime
             summary: >-
-              Certificate {{ $labels.namespace }}/{{ $labels.name }} is at 95% of its lifetime
+              Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} is at 95% of its lifetime
           expr: >
             cert:time_to_expiration:sec/cert:validity_duration:sec < 0.05
           labels:


### PR DESCRIPTION
on OCP clusters where the cluster monitoring operator is used (as advised in README) instead of the user-workload-monitoring stack, the `namespace` in the metrics is always the one of the cert-utils-operator. The namespace of the secret/certificate gets rewritten to exported_namespace by default. Not 100% sure if this is the correct place to fix this though?