### PR TITLE
Fix helm chart issues if cert-manager is disabled

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -55,7 +55,11 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
+        {{- if .Values.enableCertManager }}
         - name: webhook-server-cert
+        {{- else }}
+        - name: cert-utils-operator-certs
+        {{- end }}
           readOnly: true
           mountPath: /tmp/k8s-webhook-server/serving-certs
         {{- with .Values.env }}
@@ -93,8 +97,10 @@ spec:
       - name: cert-utils-operator-certs
         secret:
           defaultMode: 420
-          secretName: cert-utils-operator-certs 
+          secretName: cert-utils-operator-certs
+      {{- if .Values.enableCertManager }}
       - name: webhook-server-cert
         secret:
           secretName: webhook-server-cert
-          defaultMode: 420              
+          defaultMode: 420
+      {{- end }}


### PR DESCRIPTION
The issues mentioned in  #132 and #137 are still not resolved. This PR aims to fix another aspect of them, i.e., the effect on the manger's deployment.

Alternative solution:
- Add flag to `values.yaml` to disable the webhook in general.
- Generate the webhook service certificate with the `service.alpha.openshift.io/serving-cert-secret-name` annotation too.