### PR TITLE
reduce default log level for kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,6 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
         - "--tls-cert-file=/etc/certs/tls/tls.crt"
         - "--tls-private-key-file=/etc/certs/tls/tls.key"
         volumeMounts:

--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -32,7 +32,6 @@ spec:
         - --logtostderr=true
         - --tls-cert-file=/etc/certs/tls/tls.crt
         - --tls-private-key-file=/etc/certs/tls/tls.key
-        - --v=10
         image: "{{ .Values.kube_rbac_proxy.image.repository }}:{{ .Values.kube_rbac_proxy.image.tag }}"
         name: kube-rbac-proxy
         ports:


### PR DESCRIPTION
Reduce log level for proxy.  Fixes #153 