### PR TITLE
remove reference to non-existing secret volume

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -54,7 +54,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
-        - name: webhook-server-cert
+        - name: cert-utils-operator-certs
           readOnly: true
           mountPath: /tmp/k8s-webhook-server/serving-certs
         {{- with .Values.env }}
@@ -93,7 +93,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: cert-utils-operator-certs 
-      - name: webhook-server-cert
-        secret:
-          secretName: webhook-server-cert
-          defaultMode: 420              


### PR DESCRIPTION
the scecret `webhook-server-cert` is referenced by the deployment but not created by the helm chart.

we can simply use the service certs for the webhook as well.