### PR TITLE
Update PrometheusRule to not alert on already expired certificates

### DIFF
--- a/config/prometheus/rules.yaml
+++ b/config/prometheus/rules.yaml
@@ -19,7 +19,7 @@ spec:
             summary: >-
               Certificate {{ $labels.namespace }}/{{ $labels.name }} is at 85% of its lifetime
           expr: |
-            cert:time_to_expiration:sec/cert:validity_duration:sec < 0.15
+            (cert:time_to_expiration:sec/cert:validity_duration:sec < 0.15) and (cert:time_to_expiration:sec > 0)
           labels:
             severity: warning
         - alert: CertificateIsAboutToExpire
@@ -29,6 +29,6 @@ spec:
             summary: >-
               Certificate {{ $labels.namespace }}/{{ $labels.name }} is at 95% of its lifetime
           expr: >
-            cert:time_to_expiration:sec/cert:validity_duration:sec < 0.05
+            (cert:time_to_expiration:sec/cert:validity_duration:sec < 0.05) and (cert:time_to_expiration:sec > 0)
           labels:
             severity: critical


### PR DESCRIPTION
Alternatively one could compare to `-604800` instead of 0 in order to include the certs having expired in the past 7 days.

This limits alerting noise due to certificates that are not replaced in-place on rotation, for example the serving-certs in openshift-kube-controller-manager that accumulate to great numbers over the years.